### PR TITLE
Add various preview functions, making them customizable

### DIFF
--- a/README.org
+++ b/README.org
@@ -162,14 +162,14 @@
    :ID:       360EC6A5-F76A-45E9-9797-F2992CE64FEC
    :END:
 
-   p-search will only show you the first =p-search-top-n= values of the
-   search results.  If you are not seeing relevant results you may
+   p-search will only show you the first =p-search-top-n= values of
+   the search results.  If you are not seeing relevant results you may
    want to consider adding search criteria. You can also run the
    command =p-search-observe= to lower the probability of a particular
    result.  Doing so will lower the probability of the item by
-   0.3. With prefix =C-u p-search-observe=, you can specify the
-   probability.  After you perform the observation the probabilities
-   will be recalculated and the results will update.
+   multiplying it by 0.3. With prefix =C-u p-search-observe=, you can
+   specify the probability.  After you perform the observation the
+   probabilities will be recalculated and the results will update.
 
 
 *** p-search-peruse-mode

--- a/p-search.el
+++ b/p-search.el
@@ -1565,7 +1565,6 @@ If SIZE is provided create the heap with this size."
 (defun p-search-calculate (&optional no-reprint)
   "Calculate the posterior probabilities of all search candidates.
 If NO-REPRINT is nil, don't redraw p-search buffer."
-  (message "--- p-search-calculate")
   (let* ((documents (p-search-candidates))
          (priors p-search-priors)
          (marginal-p 0.0)
@@ -2237,15 +2236,17 @@ the heading to the point where BODY leaves off."
     (with-temp-buffer
       (insert substring)
       (goto-char (point-min))
-      (while (not (eobp))
-        (insert (propertize
-                 (format (concat "%"
-                                 (number-to-string digit-ct)
-                                 "d ")
-                         line-no)
-                 'face 'line-number))
-        (forward-line 1)
-        (cl-incf line-no))
+      (if (eobp)
+          (insert (propertize (format (concat "%" (number-to-string digit-ct) "d ") line-no) 'face 'line-number))
+        (while (not (eobp))
+          (insert (propertize
+                   (format (concat "%"
+                                   (number-to-string digit-ct)
+                                   "d ")
+                           line-no)
+                   'face 'line-number))
+          (forward-line 1)
+          (cl-incf line-no)))
       (buffer-string))))
 
 (defun p-search-preview-from-hints-best-section (hints)

--- a/p-search.el
+++ b/p-search.el
@@ -2343,10 +2343,12 @@ the heading to the point where BODY leaves off."
   "Return preview string of DOCUMENT.
 The number of lines returned is determined by `p-search-document-preview-size'."
   (let* ((document-contents (p-search-document-property document 'content))
-         (buffer (generate-new-buffer "*test-buffer*"))
          (priors p-search-priors)
-         (preview-size p-search-document-preview-size))
-    (with-current-buffer buffer
+         (preview-size p-search-document-preview-size)
+         (session-tfs p-search-query-session-tf-ht)
+         (candidates (p-search-candidates))
+         (final-result))
+    (with-temp-buffer
       (let* ((p-search-document-preview-size preview-size))
         ;; TODO: Add local variable to be able to refer to document
         ;;       Like how would git author provide text hints?
@@ -2358,6 +2360,10 @@ The number of lines returned is determined by `p-search-document-preview-size'."
               (let ((buffer-file-name (cadr document)))
                 (set-auto-mode))
             (setq delay-mode-hooks nil)))
+        ;; using temp buffers and local state makes things really confusing...
+        ;; the following setqs is for the code to be able to accesss certain session variables
+        (setq p-search-query-session-tf-ht session-tfs)
+        (setq p-search-candidates-cache candidates)
         (goto-char (point-min))
         (let* ((hints (p-search--document-hints priors)))
           (if hints


### PR DESCRIPTION
Adds new defcustom:

```
(defcustom p-search-default-preview-function #'p-search-preview-from-hints-best-section
  "Function to use to generate previews.  The function should assume
it is running with an active buffer of the text to generate a
preview for, correctly fontified and all. The function should
accept one argument, `hints', which is a list of hints.  A hint
is a list whoes first element is a cons pair (A . B) where A and
B are the start and end of the match respectively.  The CDR of a
hint is a plist with additional metadata, the most prominent of
which is the `:score', a measure of how important the hint is.
This is a floating point number ranging from zero to 20.

The current prebuild preview functions are
`p-search-preview-from-hints-best-section',
`p-search-preview-from-hints-top-score', and
`p-search-preview-from-hints-first-n'."

  :group 'p-search)
```