### PR TITLE
Implement BibTeX Candidate Generator/Mapping

### DIFF
--- a/docs/p-search.info
+++ b/docs/p-search.info
@@ -87,6 +87,7 @@ Candidate Generators
 * Inputs and Options::
 * Built-in Candidate Generator: FILESYSTEM::
 * Built-in Candidate Generator: BUFFERS::
+* Extension Candidate Generator: BIBTEX::
 * Extension Candidate Generator: ELISP::
 * Extension Candidate Generator: INFO::
 * Extension Candidate Generator: PACKAGE-LIST::
@@ -710,6 +711,7 @@ extensions, *note Creating Candidate Generators::.
 * Inputs and Options::
 * Built-in Candidate Generator: FILESYSTEM::
 * Built-in Candidate Generator: BUFFERS::
+* Extension Candidate Generator: BIBTEX::
 * Extension Candidate Generator: ELISP::
 * Extension Candidate Generator: INFO::
 * Extension Candidate Generator: PACKAGE-LIST::
@@ -816,7 +818,7 @@ following arguments when creating a filesystem candidate generator:
 options all begin with a dash.
 
 
-File: p-search.info,  Node: Built-in Candidate Generator: BUFFERS,  Next: Extension Candidate Generator: ELISP,  Prev: Built-in Candidate Generator: FILESYSTEM,  Up: Candidate Generators
+File: p-search.info,  Node: Built-in Candidate Generator: BUFFERS,  Next: Extension Candidate Generator: BIBTEX,  Prev: Built-in Candidate Generator: FILESYSTEM,  Up: Candidate Generators
 
 4.3.4 Built-in Candidate Generator: BUFFERS
 -------------------------------------------
@@ -828,9 +830,25 @@ configuration options.  Every buffer in your Emacs session will then
 become a search candidate.
 
 
-File: p-search.info,  Node: Extension Candidate Generator: ELISP,  Next: Extension Candidate Generator: INFO,  Prev: Built-in Candidate Generator: BUFFERS,  Up: Candidate Generators
+File: p-search.info,  Node: Extension Candidate Generator: BIBTEX,  Next: Extension Candidate Generator: ELISP,  Prev: Built-in Candidate Generator: BUFFERS,  Up: Candidate Generators
 
-4.3.5 Extension Candidate Generator: ELISP
+4.3.5 Extension Candidate Generator: BIBTEX
+-------------------------------------------
+
+The BIBTEX candidate generator (‘psx-bibtex’) turns a series of BibTeX
+or CSL-JSON files into a sequence of p-search searchable documents.
+This is done using the parsebib library.  There is a single, mandatory
+configuration option, as follows:
+
+‘f’ BibTeX Filename ‘files’
+     In interactive use, the path of a single BibTeX or CSL-JSON file.
+     When used as part of ‘p-search-default-command-behavior’, a list of
+     files can be provided instead.
+
+
+File: p-search.info,  Node: Extension Candidate Generator: ELISP,  Next: Extension Candidate Generator: INFO,  Prev: Extension Candidate Generator: BIBTEX,  Up: Candidate Generators
+
+4.3.6 Extension Candidate Generator: ELISP
 ------------------------------------------
 
 The ELISP candidate generator (‘psx-elisp’) can be used to search Emacs
@@ -844,7 +862,7 @@ can provide it with the following option:
 
 File: p-search.info,  Node: Extension Candidate Generator: INFO,  Next: Extension Candidate Generator: PACKAGE-LIST,  Prev: Extension Candidate Generator: ELISP,  Up: Candidate Generators
 
-4.3.6 Extension Candidate Generator: INFO
+4.3.7 Extension Candidate Generator: INFO
 -----------------------------------------
 
 p-search also provides a candidate generator to search GNU Info
@@ -861,7 +879,7 @@ create a candidate generator for each.
 
 File: p-search.info,  Node: Extension Candidate Generator: PACKAGE-LIST,  Prev: Extension Candidate Generator: INFO,  Up: Candidate Generators
 
-4.3.7 Extension Candidate Generator: PACKAGE-LIST
+4.3.8 Extension Candidate Generator: PACKAGE-LIST
 -------------------------------------------------
 
 The PACKAGE-LIST candidate generator (‘psx-package-list’) allows you to
@@ -2305,64 +2323,65 @@ included, this too would greatly slow down p-search.
 
 Tag Table:
 Node: Top764
-Node: Introduction3567
-Node: The Search Candidates5903
-Node: Candidate Mappings7364
-Node: Asserting Probabilities8599
-Node: Searching and Making Observations10394
-Node: Installation12004
-Node: Installing from Quelpa12468
-Node: Installing with Straight12878
-Node: Recommended Tooling13205
-Node: Getting Started13560
-Node: Creating the p-search session14000
-Node: Adding Search Criteria15790
-Node: Refining our Search19069
-Node: Final Results20848
-Node: The p-search Interface22330
-Node: Starting a session22649
-Node: The p-search session buffer25256
-Node: Candidate Generators26259
-Node: Creating and Editing Candidate Generators27536
-Node: Inputs and Options29821
-Node: Built-in Candidate Generator: FILESYSTEM30603
-Node: Built-in Candidate Generator: BUFFERS32498
-Node: Extension Candidate Generator: ELISP33072
-Node: Extension Candidate Generator: INFO33721
-Node: Extension Candidate Generator: PACKAGE-LIST34464
-Node: Mappings34935
-Node: Creating and Editing Mappings36375
-Node: Extension Mapping: File Split38154
-Node: Extension Mapping: Denote38606
-Node: Extension Mapping: PDF Info39639
-Node: Priors40364
-Node: Creating and Editing Priors41594
-Node: Scoring42771
-Node: Importance and Complement Options44108
-Node: Text Queries45979
-Node: Text Query Syntax48832
-Node: Fields52093
-Node: Searching Category53065
-Node: Instruction Strings53786
-Node: Git-related Priors54419
-Node: Filesystem-related Priors57031
-Node: Troubleshooting Priors58248
-Node: Search Results59144
-Node: Navigating and Viewing Search Results60146
-Node: Making Observations61680
-Node: Search Result Preview63162
-Node: Saving Sessions64573
-Node: Extending p-search64719
-Node: Creating Candidate Generators65349
-Node: Creating Documents69862
-Node: Creating Mappings73332
-Node: Input/Options Specification77495
-Node: Creating Priors81918
-Node: The Preset Data Structure and Programatically Creating Sessions85755
-Node: Examples of Extending p-search88725
-Node: Candidate Generator Examples89208
-Node: A Candidate Generator with Hard-coded Items89662
-Node: Defining Custom Properties91563
+Node: Introduction3609
+Node: The Search Candidates5945
+Node: Candidate Mappings7406
+Node: Asserting Probabilities8641
+Node: Searching and Making Observations10436
+Node: Installation12046
+Node: Installing from Quelpa12510
+Node: Installing with Straight12920
+Node: Recommended Tooling13247
+Node: Getting Started13602
+Node: Creating the p-search session14042
+Node: Adding Search Criteria15832
+Node: Refining our Search19111
+Node: Final Results20890
+Node: The p-search Interface22372
+Node: Starting a session22691
+Node: The p-search session buffer25298
+Node: Candidate Generators26301
+Node: Creating and Editing Candidate Generators27620
+Node: Inputs and Options29905
+Node: Built-in Candidate Generator: FILESYSTEM30687
+Node: Built-in Candidate Generator: BUFFERS32582
+Node: Extension Candidate Generator: BIBTEX33157
+Node: Extension Candidate Generator: ELISP33903
+Node: Extension Candidate Generator: INFO34552
+Node: Extension Candidate Generator: PACKAGE-LIST35295
+Node: Mappings35766
+Node: Creating and Editing Mappings37206
+Node: Extension Mapping: File Split38985
+Node: Extension Mapping: Denote39437
+Node: Extension Mapping: PDF Info40470
+Node: Priors41195
+Node: Creating and Editing Priors42425
+Node: Scoring43602
+Node: Importance and Complement Options44939
+Node: Text Queries46810
+Node: Text Query Syntax49663
+Node: Fields52924
+Node: Searching Category53896
+Node: Instruction Strings54617
+Node: Git-related Priors55250
+Node: Filesystem-related Priors57862
+Node: Troubleshooting Priors59079
+Node: Search Results59975
+Node: Navigating and Viewing Search Results60977
+Node: Making Observations62511
+Node: Search Result Preview63993
+Node: Saving Sessions65404
+Node: Extending p-search65550
+Node: Creating Candidate Generators66180
+Node: Creating Documents70693
+Node: Creating Mappings74163
+Node: Input/Options Specification78326
+Node: Creating Priors82749
+Node: The Preset Data Structure and Programatically Creating Sessions86586
+Node: Examples of Extending p-search89556
+Node: Candidate Generator Examples90039
+Node: A Candidate Generator with Hard-coded Items90493
+Node: Defining Custom Properties92394
 
 End Tag Table
 

--- a/docs/p-search.texi
+++ b/docs/p-search.texi
@@ -574,6 +574,20 @@ generators is an arbitrary convention).  This has no associated
 configuration options.  Every buffer in your Emacs session will then
 become a search candidate.
 
+@node Extension Candidate Generator: BIBTEX
+@subsection Extension Candidate Generator: BIBTEX
+
+The BIBTEX candidate generator (@code{psx-bibtex}) turns a series of
+BibTeX or CSL-JSON files into a sequence of p-search searchable
+documents.  This is done using the parsebib library.  There is a single,
+mandatory configuration option, as follows:
+
+@table @asis
+@item @kbd{f} BibTeX Filename @code{files}
+In interactive use, the path of a single BibTeX or CSL-JSON file.  When
+used as part of @code{p-search-default-command-behavior}, a list of
+files can be provided instead.
+@end table
 
 @node Extension Candidate Generator: ELISP
 @subsection Extension Candidate Generator: ELISP

--- a/extensions/psx-bibtex.el
+++ b/extensions/psx-bibtex.el
@@ -36,13 +36,13 @@
   "Extract BibTeX Entry name from ID."
   (pcase-let* ((`(_ ,key _) id))
     key))
-(p-search-def-field 'bibtex 'name #'psx-bibtex--name)
+(p-search-def-property 'bibtex 'name #'psx-bibtex--name)
 
 (defun psx-bibtex--content (id)
   "Get entry content (i.e., abstract) from BibTeX entry ID."
   (pcase-let* ((`(_ _ ,entry-data) id))
     (alist-get "abstract" entry-data "" nil #'string-equal-ignore-case)))
-(p-search-def-field 'bibtex 'content #'psx-bibtex--content)
+(p-search-def-property 'bibtex 'content #'psx-bibtex--content)
 
 (defun psx-bibtex--fields (id)
   "Get various searchable fields from BibTeX entry ID."
@@ -60,7 +60,7 @@
       (when keywords
         (push (cons 'keywords (mapcar #'string-trim (string-split keywords ","))) fields))
       fields)))
-(p-search-def-field 'bibtex 'fields #'psx-bibtex--fields)
+(p-search-def-property 'bibtex 'fields #'psx-bibtex--fields)
 
 (defun psx-bibtex--candidate-generator (args)
   "Generate BibTeX candidates from ARGS."

--- a/extensions/psx-bibtex.el
+++ b/extensions/psx-bibtex.el
@@ -23,7 +23,17 @@
 
 ;;; Commentary:
 
+;; This package implements a BibTeX candidate generator for
+;; `p-search'.  Of note, it is designed to be used interactively, or
+;; as part of `p-search-default-command-behavior'.  When used with the
+;; latter, there is a single, mandatory option of `files', which can
+;; be set to a single file name or a list of file names, which will be
+;; read in turn.
 ;;
+;; Additionally, bibliography entries can be opened internally or
+;; externally.  This is disabled by default, but can be configured by
+;; setting `psx-bibtex-open-entry-function' to a function which takes
+;; a filename and an entry key, and opens the bibentry as you choose.
 
 ;;; Code:
 

--- a/extensions/psx-bibtex.el
+++ b/extensions/psx-bibtex.el
@@ -43,7 +43,7 @@
 This function should take two arguments, FILENAME and ENTRY-KEY,
 and will be called as follows.
 
-\(apply psx-bibtex-open-entry-function filename entry-key)"
+    (apply psx-bibtex-open-entry-function filename entry-key)"
   :type '(choice (const :tag "Don't Open" nil)
                  (function :tag "Custom Function"))
   :group 'psx-bibtex)

--- a/extensions/psx-bibtex.el
+++ b/extensions/psx-bibtex.el
@@ -1,4 +1,4 @@
-;;; psx-bibtex.el --- P-Search BibTex Candidate Generator  -*- lexical-binding: t; -*-
+;;; psx-bibtex.el --- A BibTeX candidate generator for p-search  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2025  Samuel W. Flint
 

--- a/extensions/psx-bibtex.el
+++ b/extensions/psx-bibtex.el
@@ -3,7 +3,10 @@
 ;; Copyright (C) 2025  Samuel W. Flint
 
 ;; Author: Samuel W. Flint <me@samuelwflint.com>
+;; Version: 0.9.0
 ;; Keywords: tools, tex
+;; Package-Requires: ((emacs "25.1") (compat "29.1"))
+;; Homepage: https://github.com/zkry/p-search
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -26,7 +29,8 @@
 
 (require 'p-search)
 (require 'parsebib)
-(require 'cl)
+(require 'cl-lib)
+(require 'compat)
 
 
 ;;; Customization

--- a/extensions/psx-bibtex.el
+++ b/extensions/psx-bibtex.el
@@ -50,6 +50,12 @@
     (alist-get "abstract" entry-data "" nil #'string-equal-ignore-case)))
 (p-search-def-property 'bibtex 'content #'psx-bibtex--content)
 
+(defun psx-bibtex--filename (id)
+  "Get entry filename from ID."
+  (pcase-let* ((`(,file _ _) id))
+    file))
+(p-search-def-property 'bibtex 'file-name #'psx-bibtex--filename)
+
 (defun psx-bibtex--fields (id)
   "Get various searchable fields from BibTeX entry ID."
   (pcase-let* ((`(,file _ ,entry-data) id))

--- a/extensions/psx-bibtex.el
+++ b/extensions/psx-bibtex.el
@@ -1,0 +1,68 @@
+;;; psx-bibtex.el --- P-Search BibTex Candidate Generator  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Samuel W. Flint
+
+;; Author: Samuel W. Flint <me@samuelwflint.com>
+;; Keywords: tools, tex
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;
+
+;;; Code:
+
+(require 'p-search)
+(require 'parsebib)
+(require 'cl)
+
+(defun psx-bibtex--lighter (config)
+  "Describe (briefly) BibTex Candidate generator CONFIG."
+  (format "BIBTEX:%s" (alist-get 'file input-options-alist)))
+
+(p-search-def-property 'bibtex 'id #'cl-first)
+(p-search-def-property 'bibtex 'name #'cl-first)
+(p-search-def-property 'bibtex 'content #'cl-third)
+
+(defun psx-bibtex--candidate-generator (args)
+  "Generate BibTeX candidates from ARGS."
+  (let-alist args
+    (let ((entries (parsebib-parse .file))
+          documents)
+      (maphash (lambda (key entry)
+                 (push (p-search-document-extend
+                        (p-search-documentize (list 'bibtex (list key .file (alist-get "abstract" entry "" nil #'string=))))
+                        (cons 'bib key)
+                        (list (cons 'author (string-split (or (assoc-string "author" entry t) "") " and "))
+                              (cons 'title (or (assoc-string "title" entry t) ""))
+                              (cons 'keywords (string-split (or (assoc-string "keywords" entry t) "") ", "))))
+                       documents))
+               entries)
+      documents)))
+
+(defvar psx-bibtex-candidate-generator
+  (p-search-candidate-generator-create
+   :id 'psx-bibtex-candidate-generator
+   :name "BIBTEX"
+   :input-spec '((file . (p-search-infix-file
+                          :key "f"
+                          :description "BibTeX Filename")))
+   :function #'psx-bibtex--candidate-generator
+   :lighter-function #'psx-bibtex--lighter))
+
+(add-to-list 'p-search-candidate-generators psx-bibtex-candidate-generator)
+
+(provide 'psx-bibtex)
+;;; psx-bibtex.el ends here

--- a/extensions/psx-bibtex.el
+++ b/extensions/psx-bibtex.el
@@ -30,7 +30,7 @@
 
 (defun psx-bibtex--lighter (config)
   "Describe (briefly) BibTex Candidate generator CONFIG."
-  (format "BIBTEX:%s" (alist-get 'file input-options-alist)))
+  (format "BIBTEX:%s" (file-relative-name (alist-get 'file config) default-directory)))
 
 (defun psx-bibtex--name (id)
   "Extract BibTeX Entry name from ID."

--- a/extensions/psx-bibtex.el
+++ b/extensions/psx-bibtex.el
@@ -28,6 +28,9 @@
 (require 'parsebib)
 (require 'cl)
 
+
+;;; Property Definitions
+
 (defun psx-bibtex--lighter (config)
   "Describe (briefly) BibTex Candidate generator CONFIG."
   (format "BIBTEX:%s"
@@ -73,6 +76,9 @@
         (push (cons 'keywords (mapcar #'string-trim (string-split keywords ","))) fields))
       fields)))
 (p-search-def-property 'bibtex 'fields #'psx-bibtex--fields)
+
+
+;;; Candidate Generator
 
 (defun psx-bibtex--candidate-generator (args)
   "Generate BibTeX candidates from ARGS.

--- a/extensions/psx-bibtex.el
+++ b/extensions/psx-bibtex.el
@@ -88,7 +88,7 @@ ARGS should be an alist containing the following keys:
           (maphash (lambda (key entry)
                      (push (p-search-documentize (list 'bibtex (list file key entry))) documents))
                    entries)))
-      documents)))
+      (nreverse documents))))
 
 (defconst psx-bibtex-candidate-generator
   (p-search-candidate-generator-create

--- a/extensions/psx-bibtex.el
+++ b/extensions/psx-bibtex.el
@@ -29,6 +29,26 @@
 (require 'cl)
 
 
+;;; Customization
+
+(defgroup psx-bibtex nil
+  "Customization for `p-search' bibtex candidate generator."
+  :group 'p-search
+  :group 'bibtex
+  :prefix "psx-bibtex-")
+
+(defcustom psx-bibtex-open-entry-function nil
+  "Function to open a bibtex entry.
+
+This function should take two arguments, FILENAME and ENTRY-KEY,
+and will be called as follows.
+
+\(apply psx-bibtex-open-entry-function filename entry-key)"
+  :type '(choice (const :tag "Don't Open" nil)
+                 (function :tag "Custom Function"))
+  :group 'psx-bibtex)
+
+
 ;;; Property Definitions
 
 (defun psx-bibtex--lighter (config)
@@ -76,6 +96,16 @@
         (push (cons 'keywords (mapcar #'string-trim (string-split keywords ","))) fields))
       fields)))
 (p-search-def-property 'bibtex 'fields #'psx-bibtex--fields)
+
+(defun psx-bibtex--goto-entry (id)
+  "Go to BibTeX entry ID.
+
+Use `psx-bibtex-open-entry-function' if set, otherwise, do
+nothing."
+  (when psx-bibtex-open-entry-function
+    (pcase-let* ((`(,filename ,entry-key _) id))
+      (apply psx-bibtex-open-entry-function filename entry-key))))
+(p-search-def-function 'bibtex 'p-search-goto-document #'psx-bibtex--goto-entry)
 
 
 ;;; Candidate Generator


### PR DESCRIPTION
See also #42.

This PR (early stage as yet) implements a BibTeX candidate generator using the [parsebib](https://github.com/joostkremers/parsebib) library to collect BibTeX entries.