### PR TITLE
Update Documents to add places for mappings/in-repo candidate generator extensions

### DIFF
--- a/docs/p-search.info
+++ b/docs/p-search.info
@@ -1,4 +1,4 @@
-This is p-search.info, produced by texi2any version 7.1.1 from
+This is p-search.info, produced by makeinfo version 7.1.1 from
 p-search.texi.
 
      Copyright (C) 2024 Zachary Romero <zacromero@posteo.com>
@@ -85,14 +85,18 @@ Candidate Generators
 
 * Creating and Editing Candidate Generators::
 * Inputs and Options::
-* Common Candidate Generators: FILESYSTEM::
-* Common Candidate Generators: BUFFERS::
-* Common Candidate Generators: FUNCTION-SYMBOL::
-* Common Candidate Generators: INFO::
+* Built-in Candidate Generators: FILESYSTEM::
+* Built-in Candidate Generators: BUFFERS::
+* Extension Candidate Generators: ELISP::
+* Extension Candidate Generators: INFO::
+* Extension Candidate Generator: PACKAGE-LIST::
 
 Mappings
 
 * Creating and Editing Mappings::
+* Mapping Extension: File Split::
+* Mapping Extension: Denote::
+* Mapping Extension: PDF Info::
 
 Priors
 
@@ -704,10 +708,11 @@ extensions, *note Creating Candidate Generators::.
 
 * Creating and Editing Candidate Generators::
 * Inputs and Options::
-* Common Candidate Generators: FILESYSTEM::
-* Common Candidate Generators: BUFFERS::
-* Common Candidate Generators: FUNCTION-SYMBOL::
-* Common Candidate Generators: INFO::
+* Built-in Candidate Generators: FILESYSTEM::
+* Built-in Candidate Generators: BUFFERS::
+* Extension Candidate Generators: ELISP::
+* Extension Candidate Generators: INFO::
+* Extension Candidate Generator: PACKAGE-LIST::
 
 
 File: p-search.info,  Node: Creating and Editing Candidate Generators,  Next: Inputs and Options,  Up: Candidate Generators
@@ -755,7 +760,7 @@ candidates added by candidate generators are ignored.
      Priors:: more information on creating priors.
 
 
-File: p-search.info,  Node: Inputs and Options,  Next: Common Candidate Generators: FILESYSTEM,  Prev: Creating and Editing Candidate Generators,  Up: Candidate Generators
+File: p-search.info,  Node: Inputs and Options,  Next: Built-in Candidate Generators: FILESYSTEM,  Prev: Creating and Editing Candidate Generators,  Up: Candidate Generators
 
 4.3.2 Inputs and Options
 ------------------------
@@ -770,10 +775,10 @@ will have defaults.  If a default is not provided however, you will
 always be prompted for its value for it not to be blank.
 
 
-File: p-search.info,  Node: Common Candidate Generators: FILESYSTEM,  Next: Common Candidate Generators: BUFFERS,  Prev: Inputs and Options,  Up: Candidate Generators
+File: p-search.info,  Node: Built-in Candidate Generators: FILESYSTEM,  Next: Built-in Candidate Generators: BUFFERS,  Prev: Inputs and Options,  Up: Candidate Generators
 
-4.3.3 Common Candidate Generators: FILESYSTEM
----------------------------------------------
+4.3.3 Built-in Candidate Generators: FILESYSTEM
+-----------------------------------------------
 
 The remainder of the candidate generator section will cover the
 candidate generators that come packaged in p-search.  The most prominent
@@ -811,10 +816,10 @@ following arguments when creating a filesystem candidate generator:
 options all begin with a dash.
 
 
-File: p-search.info,  Node: Common Candidate Generators: BUFFERS,  Next: Common Candidate Generators: FUNCTION-SYMBOL,  Prev: Common Candidate Generators: FILESYSTEM,  Up: Candidate Generators
+File: p-search.info,  Node: Built-in Candidate Generators: BUFFERS,  Next: Extension Candidate Generators: ELISP,  Prev: Built-in Candidate Generators: FILESYSTEM,  Up: Candidate Generators
 
-4.3.4 Common Candidate Generators: BUFFERS
-------------------------------------------
+4.3.4 Built-in Candidate Generators: BUFFERS
+--------------------------------------------
 
 If you wanted to search all of your open buffers, you could create a
 "BUFFERS" candidate generator (the all caps naming for candidate
@@ -823,10 +828,10 @@ configuration options.  Every buffer in your emacs session will then
 become a search candidate.
 
 
-File: p-search.info,  Node: Common Candidate Generators: FUNCTION-SYMBOL,  Next: Common Candidate Generators: INFO,  Prev: Common Candidate Generators: BUFFERS,  Up: Candidate Generators
+File: p-search.info,  Node: Extension Candidate Generators: ELISP,  Next: Extension Candidate Generators: INFO,  Prev: Built-in Candidate Generators: BUFFERS,  Up: Candidate Generators
 
-4.3.5 Common Candidate Generators: FUNCTION-SYMBOL
---------------------------------------------------
+4.3.5 Extension Candidate Generators: ELISP
+-------------------------------------------
 
 The function symbol candidate generator can be used to search function
 symbols along with their documentation.  When being created, you can
@@ -848,10 +853,10 @@ provide it with the following options:
      that mode.
 
 
-File: p-search.info,  Node: Common Candidate Generators: INFO,  Prev: Common Candidate Generators: FUNCTION-SYMBOL,  Up: Candidate Generators
+File: p-search.info,  Node: Extension Candidate Generators: INFO,  Next: Extension Candidate Generator: PACKAGE-LIST,  Prev: Extension Candidate Generators: ELISP,  Up: Candidate Generators
 
-4.3.6 Common Candidate Generators: INFO
----------------------------------------
+4.3.6 Extension Candidate Generators: INFO
+------------------------------------------
 
 p-search also provides a candidate generator to search info files.  Once
 you select an info file, it will break it up into its constituent nodes
@@ -863,6 +868,12 @@ which can be searched on.
 
    If you wanted to search multiple info files at the same time, you can
 just create two candidate generators with the two info nodes.
+
+
+File: p-search.info,  Node: Extension Candidate Generator: PACKAGE-LIST,  Prev: Extension Candidate Generators: INFO,  Up: Candidate Generators
+
+4.3.7 Extension Candidate Generator: PACKAGE-LIST
+-------------------------------------------------
 
 
 File: p-search.info,  Node: Mappings,  Next: Priors,  Prev: Candidate Generators,  Up: The p-search Interface
@@ -895,9 +906,12 @@ later chapter (*note Creating Mappings::).
 * Menu:
 
 * Creating and Editing Mappings::
+* Mapping Extension: File Split::
+* Mapping Extension: Denote::
+* Mapping Extension: PDF Info::
 
 
-File: p-search.info,  Node: Creating and Editing Mappings,  Up: Mappings
+File: p-search.info,  Node: Creating and Editing Mappings,  Next: Mapping Extension: File Split,  Up: Mappings
 
 4.4.1 Creating and Editing Mappings
 -----------------------------------
@@ -931,6 +945,24 @@ or more deriving documents, nil meaning nothing can be done, or
 ‘:remove’, which explicitly removes a document.  Every mapping can be
 created with the option ‘-f’ (‘filter’).  When on, a mapping that
 doesn't do anything to a document will remove the document.
+
+
+File: p-search.info,  Node: Mapping Extension: File Split,  Next: Mapping Extension: Denote,  Prev: Creating and Editing Mappings,  Up: Mappings
+
+4.4.2 Mapping Extension: File Split
+-----------------------------------
+
+
+File: p-search.info,  Node: Mapping Extension: Denote,  Next: Mapping Extension: PDF Info,  Prev: Mapping Extension: File Split,  Up: Mappings
+
+4.4.3 Mapping Extension: Denote
+-------------------------------
+
+
+File: p-search.info,  Node: Mapping Extension: PDF Info,  Prev: Mapping Extension: Denote,  Up: Mappings
+
+4.4.4 Mapping Extension: PDF Info
+---------------------------------
 
 
 File: p-search.info,  Node: Priors,  Next: Search Results,  Prev: Mappings,  Up: The p-search Interface
@@ -2220,60 +2252,64 @@ included, this too would greatly slow down p-search.
 
 Tag Table:
 Node: Top764
-Node: Introduction3427
-Node: The Search Candidates5763
-Node: Candidate Mappings7224
-Node: Asserting Probabilities8459
-Node: Searching and Making Observations10254
-Node: Installation11864
-Node: Installing from Quelpa12328
-Node: Installing with Straight12738
-Node: Recommended Tooling13065
-Node: Getting Started13420
-Node: Creating the p-search session13860
-Node: Adding Search Criteria15650
-Node: Refining our Search18929
-Node: Final Results20708
-Node: The p-search Interface22190
-Node: Starting a session22509
-Node: The p-search session buffer25116
-Node: Candidate Generators26119
-Node: Creating and Editing Candidate Generators27352
-Node: Inputs and Options29637
-Node: Common Candidate Generators: FILESYSTEM30418
-Node: Common Candidate Generators: BUFFERS32196
-Node: Common Candidate Generators: FUNCTION-SYMBOL32774
-Node: Common Candidate Generators: INFO33854
-Node: Mappings34534
-Node: Creating and Editing Mappings35878
-Node: Priors37619
-Node: Creating and Editing Priors38849
-Node: Scoring40026
-Node: Importance and Complement Options41363
-Node: Text Queries43234
-Node: Text Query Syntax46087
-Node: Fields49348
-Node: Searching Category50320
-Node: Instruction Strings51041
-Node: Git-related Priors51674
-Node: Filesystem-related Priors54286
-Node: Troubleshooting Priors55503
-Node: Search Results56399
-Node: Navigating and Viewing Search Results57401
-Node: Making Observations58935
-Node: Search Result Preview60417
-Node: Saving Sessions61828
-Node: Extending p-search61974
-Node: Creating Candidate Generators62604
-Node: Creating Documents67117
-Node: Creating Mappings70587
-Node: Input/Options Specification74750
-Node: Creating Priors79173
-Node: The Preset Data Structure and Programatically Creating Sessions83010
-Node: Examples of Extending p-search85980
-Node: Candidate Generator Examples86463
-Node: A Candidate Generator with Hard-coded Items86917
-Node: Defining Custom Properties88818
+Node: Introduction3571
+Node: The Search Candidates5907
+Node: Candidate Mappings7368
+Node: Asserting Probabilities8603
+Node: Searching and Making Observations10398
+Node: Installation12008
+Node: Installing from Quelpa12472
+Node: Installing with Straight12882
+Node: Recommended Tooling13209
+Node: Getting Started13564
+Node: Creating the p-search session14004
+Node: Adding Search Criteria15794
+Node: Refining our Search19073
+Node: Final Results20852
+Node: The p-search Interface22334
+Node: Starting a session22653
+Node: The p-search session buffer25260
+Node: Candidate Generators26263
+Node: Creating and Editing Candidate Generators27544
+Node: Inputs and Options29829
+Node: Built-in Candidate Generators: FILESYSTEM30612
+Node: Built-in Candidate Generators: BUFFERS32398
+Node: Extension Candidate Generators: ELISP32977
+Node: Extension Candidate Generators: INFO34041
+Node: Extension Candidate Generator: PACKAGE-LIST34775
+Node: Mappings35023
+Node: Creating and Editing Mappings36463
+Node: Mapping Extension: File Split38242
+Node: Mapping Extension: Denote38463
+Node: Mapping Extension: PDF Info38674
+Node: Priors38851
+Node: Creating and Editing Priors40081
+Node: Scoring41258
+Node: Importance and Complement Options42595
+Node: Text Queries44466
+Node: Text Query Syntax47319
+Node: Fields50580
+Node: Searching Category51552
+Node: Instruction Strings52273
+Node: Git-related Priors52906
+Node: Filesystem-related Priors55518
+Node: Troubleshooting Priors56735
+Node: Search Results57631
+Node: Navigating and Viewing Search Results58633
+Node: Making Observations60167
+Node: Search Result Preview61649
+Node: Saving Sessions63060
+Node: Extending p-search63206
+Node: Creating Candidate Generators63836
+Node: Creating Documents68349
+Node: Creating Mappings71819
+Node: Input/Options Specification75982
+Node: Creating Priors80405
+Node: The Preset Data Structure and Programatically Creating Sessions84242
+Node: Examples of Extending p-search87212
+Node: Candidate Generator Examples87695
+Node: A Candidate Generator with Hard-coded Items88149
+Node: Defining Custom Properties90050
 
 End Tag Table
 

--- a/docs/p-search.info
+++ b/docs/p-search.info
@@ -1,4 +1,4 @@
-This is p-search.info, produced by makeinfo version 7.1.1 from
+This is p-search.info, produced by texi2any version 7.1.1 from
 p-search.texi.
 
      Copyright (C) 2024 Zachary Romero <zacromero@posteo.com>
@@ -85,18 +85,18 @@ Candidate Generators
 
 * Creating and Editing Candidate Generators::
 * Inputs and Options::
-* Built-in Candidate Generators: FILESYSTEM::
-* Built-in Candidate Generators: BUFFERS::
-* Extension Candidate Generators: ELISP::
-* Extension Candidate Generators: INFO::
+* Built-in Candidate Generator: FILESYSTEM::
+* Built-in Candidate Generator: BUFFERS::
+* Extension Candidate Generator: ELISP::
+* Extension Candidate Generator: INFO::
 * Extension Candidate Generator: PACKAGE-LIST::
 
 Mappings
 
 * Creating and Editing Mappings::
-* Mapping Extension: File Split::
-* Mapping Extension: Denote::
-* Mapping Extension: PDF Info::
+* Extension Mapping: File Split::
+* Extension Mapping: Denote::
+* Extension Mapping: PDF Info::
 
 Priors
 
@@ -708,10 +708,10 @@ extensions, *note Creating Candidate Generators::.
 
 * Creating and Editing Candidate Generators::
 * Inputs and Options::
-* Built-in Candidate Generators: FILESYSTEM::
-* Built-in Candidate Generators: BUFFERS::
-* Extension Candidate Generators: ELISP::
-* Extension Candidate Generators: INFO::
+* Built-in Candidate Generator: FILESYSTEM::
+* Built-in Candidate Generator: BUFFERS::
+* Extension Candidate Generator: ELISP::
+* Extension Candidate Generator: INFO::
 * Extension Candidate Generator: PACKAGE-LIST::
 
 
@@ -760,7 +760,7 @@ candidates added by candidate generators are ignored.
      Priors:: more information on creating priors.
 
 
-File: p-search.info,  Node: Inputs and Options,  Next: Built-in Candidate Generators: FILESYSTEM,  Prev: Creating and Editing Candidate Generators,  Up: Candidate Generators
+File: p-search.info,  Node: Inputs and Options,  Next: Built-in Candidate Generator: FILESYSTEM,  Prev: Creating and Editing Candidate Generators,  Up: Candidate Generators
 
 4.3.2 Inputs and Options
 ------------------------
@@ -775,10 +775,10 @@ will have defaults.  If a default is not provided however, you will
 always be prompted for its value for it not to be blank.
 
 
-File: p-search.info,  Node: Built-in Candidate Generators: FILESYSTEM,  Next: Built-in Candidate Generators: BUFFERS,  Prev: Inputs and Options,  Up: Candidate Generators
+File: p-search.info,  Node: Built-in Candidate Generator: FILESYSTEM,  Next: Built-in Candidate Generator: BUFFERS,  Prev: Inputs and Options,  Up: Candidate Generators
 
-4.3.3 Built-in Candidate Generators: FILESYSTEM
------------------------------------------------
+4.3.3 Built-in Candidate Generator: FILESYSTEM
+----------------------------------------------
 
 The remainder of the candidate generator section will cover the
 candidate generators that come packaged in p-search.  The most prominent
@@ -787,24 +787,24 @@ creating this in a variety of situations.  The candidate generator makes
 a document for each file in a directory.  You will be prompted for the
 following arguments when creating a filesystem candidate generator:
 
-‘d’ Directory
+‘d’ Directory (‘base-directory’)
      The directory from which all candidates will be produced.
 
-‘f’ Filename Pattern
+‘f’ Filename Pattern (‘filename-regexp’)
      A regular expression that all candidate files must match.  Use ".*"
      to match all files.
 
-‘t’ Search Tool
+‘t’ Search Tool (‘search-tool’)
      The CLI tool used to perform the term frequency search.  At the
      moment, the filesystem candidate generator supports the tools
      ripgrep (recommended), ag, and grep.  These tools will be used when
      creating a "text query" prior.
 
-‘-i’ Ignore Pattern
+‘-i’ Ignore Pattern (‘ignore-pattern’)
      A regular expression which can be provided to specify files not to
      match.
 
-‘-g’ Git ls-files
+‘-g’ Git ls-files (‘use-git-ignore’)
      Use the command ‘git ls-files’ to enumerate the candidates.  If
      your directory is a Git repository, it is *strongly* recommended
      that you turn this setting on to ignore files not committed to git.
@@ -816,64 +816,58 @@ following arguments when creating a filesystem candidate generator:
 options all begin with a dash.
 
 
-File: p-search.info,  Node: Built-in Candidate Generators: BUFFERS,  Next: Extension Candidate Generators: ELISP,  Prev: Built-in Candidate Generators: FILESYSTEM,  Up: Candidate Generators
+File: p-search.info,  Node: Built-in Candidate Generator: BUFFERS,  Next: Extension Candidate Generator: ELISP,  Prev: Built-in Candidate Generator: FILESYSTEM,  Up: Candidate Generators
 
-4.3.4 Built-in Candidate Generators: BUFFERS
---------------------------------------------
+4.3.4 Built-in Candidate Generator: BUFFERS
+-------------------------------------------
 
 If you wanted to search all of your open buffers, you could create a
 "BUFFERS" candidate generator (the all caps naming for candidate
 generators is an arbitrary convention).  This has no associated
-configuration options.  Every buffer in your emacs session will then
+configuration options.  Every buffer in your Emacs session will then
 become a search candidate.
 
 
-File: p-search.info,  Node: Extension Candidate Generators: ELISP,  Next: Extension Candidate Generators: INFO,  Prev: Built-in Candidate Generators: BUFFERS,  Up: Candidate Generators
+File: p-search.info,  Node: Extension Candidate Generator: ELISP,  Next: Extension Candidate Generator: INFO,  Prev: Built-in Candidate Generator: BUFFERS,  Up: Candidate Generators
 
-4.3.5 Extension Candidate Generators: ELISP
--------------------------------------------
-
-The function symbol candidate generator can be used to search function
-symbols along with their documentation.  When being created, you can
-provide it with the following options:
-
-‘s’ Symbol Name Regex
-     A regular expression which the symbol's name must match in order
-     for it to be considered a candidate.  For example, if you wanted to
-     search org functions, you could use the regular expression "^org".
-
-‘-c’ Is Command?
-     When set to true, the candidate generator will only make documents
-     for symbols that are defined as commands (i.e.  with
-     ‘(interactive)’).
-
-‘-m’ Major Mode
-     Search for commands as if you were in the selected major mode and
-     ran ‘M-X’ (‘execute-extended-command-for-buffer’) in a buffer of
-     that mode.
-
-
-File: p-search.info,  Node: Extension Candidate Generators: INFO,  Next: Extension Candidate Generator: PACKAGE-LIST,  Prev: Extension Candidate Generators: ELISP,  Up: Candidate Generators
-
-4.3.6 Extension Candidate Generators: INFO
+4.3.5 Extension Candidate Generator: ELISP
 ------------------------------------------
 
-p-search also provides a candidate generator to search info files.  Once
-you select an info file, it will break it up into its constituent nodes
-which can be searched on.
+The ELISP candidate generator (‘psx-elisp’) can be used to search Emacs
+Lisp symbols along with their documentation.  When being created, you
+can provide it with the following option:
 
-‘i’ Info Node
-     The name of the info file to search.  The possible info files are
-     taken from the variable ‘Info-directory-list’.
-
-   If you wanted to search multiple info files at the same time, you can
-just create two candidate generators with the two info nodes.
+‘t’ Symbol Type ‘symbol-type’
+     A keyword, one of: ‘:all’ for all symbols (default), ‘:functions’
+     for all function symbols, or ‘:variables’ for all variables.
 
 
-File: p-search.info,  Node: Extension Candidate Generator: PACKAGE-LIST,  Prev: Extension Candidate Generators: INFO,  Up: Candidate Generators
+File: p-search.info,  Node: Extension Candidate Generator: INFO,  Next: Extension Candidate Generator: PACKAGE-LIST,  Prev: Extension Candidate Generator: ELISP,  Up: Candidate Generators
+
+4.3.6 Extension Candidate Generator: INFO
+-----------------------------------------
+
+p-search also provides a candidate generator to search GNU Info
+documents (‘psx-info’).  Once you select an Info file, it will be broken
+up into its constituent nodes for further search.
+
+‘i’ Info Node ‘info-node’
+     The name of the info file to search.  The possible Info files are
+     taken from the variable ‘Info-directory-list’.
+
+   If you wanted to search multiple Info files at the same time, you can
+create a candidate generator for each.
+
+
+File: p-search.info,  Node: Extension Candidate Generator: PACKAGE-LIST,  Prev: Extension Candidate Generator: INFO,  Up: Candidate Generators
 
 4.3.7 Extension Candidate Generator: PACKAGE-LIST
 -------------------------------------------------
+
+The PACKAGE-LIST candidate generator (‘psx-package-list’) allows you to
+search through Emacs packages.  This candidate generator has no options,
+and will create documents for each package your installation knows
+about.
 
 
 File: p-search.info,  Node: Mappings,  Next: Priors,  Prev: Candidate Generators,  Up: The p-search Interface
@@ -906,12 +900,12 @@ later chapter (*note Creating Mappings::).
 * Menu:
 
 * Creating and Editing Mappings::
-* Mapping Extension: File Split::
-* Mapping Extension: Denote::
-* Mapping Extension: PDF Info::
+* Extension Mapping: File Split::
+* Extension Mapping: Denote::
+* Extension Mapping: PDF Info::
 
 
-File: p-search.info,  Node: Creating and Editing Mappings,  Next: Mapping Extension: File Split,  Up: Mappings
+File: p-search.info,  Node: Creating and Editing Mappings,  Next: Extension Mapping: File Split,  Up: Mappings
 
 4.4.1 Creating and Editing Mappings
 -----------------------------------
@@ -947,22 +941,81 @@ created with the option ‘-f’ (‘filter’).  When on, a mapping that
 doesn't do anything to a document will remove the document.
 
 
-File: p-search.info,  Node: Mapping Extension: File Split,  Next: Mapping Extension: Denote,  Prev: Creating and Editing Mappings,  Up: Mappings
+File: p-search.info,  Node: Extension Mapping: File Split,  Next: Extension Mapping: Denote,  Prev: Creating and Editing Mappings,  Up: Mappings
 
-4.4.2 Mapping Extension: File Split
+4.4.2 Extension Mapping: File Split
 -----------------------------------
 
-
-File: p-search.info,  Node: Mapping Extension: Denote,  Next: Mapping Extension: PDF Info,  Prev: Mapping Extension: File Split,  Up: Mappings
+The File Split mapping (‘psx-file-split’) splits existing documents into
+smaller sections, based on a number of lines.  It has one option:
 
-4.4.3 Mapping Extension: Denote
+‘n’ Split by N lines ‘split-size’
+     Number of lines to split documents by.
+
+
+File: p-search.info,  Node: Extension Mapping: Denote,  Next: Extension Mapping: PDF Info,  Prev: Extension Mapping: File Split,  Up: Mappings
+
+4.4.3 Extension Mapping: Denote
 -------------------------------
 
-
-File: p-search.info,  Node: Mapping Extension: PDF Info,  Prev: Mapping Extension: Denote,  Up: Mappings
+The Denote mapping (‘psx-denote’) provides a selection of denote-derived
+fields for search.  Mapped fields include as follows:
 
-4.4.4 Mapping Extension: PDF Info
+‘denote-type’
+     The type of the Denote document.
+
+‘denote-identifier’
+     The Denote document's identifier.
+
+‘denote-signature’
+     The Denote document's signature, if it exists and signatures are
+     requested.
+
+‘keywords’
+     The Denote document's keywords, extracted from the filename.
+
+‘title’
+     The Denote document's title, extracted from the file name, and if
+     different, from the file itself.
+
+   This mapping has one option, as follows:
+
+‘-s’ Include Signature ‘include-signature’
+     Whether document signatures should be included, when present.  The
+     default for this value is provided by
+     ‘psx-denote-include-signature-p’.
+
+
+File: p-search.info,  Node: Extension Mapping: PDF Info,  Prev: Extension Mapping: Denote,  Up: Mappings
+
+4.4.4 Extension Mapping: PDF Info
 ---------------------------------
+
+The PDF Info mapping (‘psx-pdfinfo’) collects metadata from PDF
+documents.  There are no options on mapping creation, but the
+‘psx-pdfinfo-executable’ variable can be used to configure the location
+of your preferred ‘pdfinfo’ command.  The following metadata fields are
+collected:
+
+   • ‘title’
+
+   • ‘keywords’
+
+   • ‘author’
+
+   • ‘creation-date’
+
+   • ‘modification-date’
+
+   • ‘pdf-subject’
+
+   • ‘pdf-creator’
+
+   • ‘pdf-producer’
+
+   • ‘pdf-pages’
+
+   • ‘pdf-pagesize’
 
 
 File: p-search.info,  Node: Priors,  Next: Search Results,  Prev: Mappings,  Up: The p-search Interface
@@ -2252,64 +2305,64 @@ included, this too would greatly slow down p-search.
 
 Tag Table:
 Node: Top764
-Node: Introduction3571
-Node: The Search Candidates5907
-Node: Candidate Mappings7368
-Node: Asserting Probabilities8603
-Node: Searching and Making Observations10398
-Node: Installation12008
-Node: Installing from Quelpa12472
-Node: Installing with Straight12882
-Node: Recommended Tooling13209
-Node: Getting Started13564
-Node: Creating the p-search session14004
-Node: Adding Search Criteria15794
-Node: Refining our Search19073
-Node: Final Results20852
-Node: The p-search Interface22334
-Node: Starting a session22653
-Node: The p-search session buffer25260
-Node: Candidate Generators26263
-Node: Creating and Editing Candidate Generators27544
-Node: Inputs and Options29829
-Node: Built-in Candidate Generators: FILESYSTEM30612
-Node: Built-in Candidate Generators: BUFFERS32398
-Node: Extension Candidate Generators: ELISP32977
-Node: Extension Candidate Generators: INFO34041
-Node: Extension Candidate Generator: PACKAGE-LIST34775
-Node: Mappings35023
-Node: Creating and Editing Mappings36463
-Node: Mapping Extension: File Split38242
-Node: Mapping Extension: Denote38463
-Node: Mapping Extension: PDF Info38674
-Node: Priors38851
-Node: Creating and Editing Priors40081
-Node: Scoring41258
-Node: Importance and Complement Options42595
-Node: Text Queries44466
-Node: Text Query Syntax47319
-Node: Fields50580
-Node: Searching Category51552
-Node: Instruction Strings52273
-Node: Git-related Priors52906
-Node: Filesystem-related Priors55518
-Node: Troubleshooting Priors56735
-Node: Search Results57631
-Node: Navigating and Viewing Search Results58633
-Node: Making Observations60167
-Node: Search Result Preview61649
-Node: Saving Sessions63060
-Node: Extending p-search63206
-Node: Creating Candidate Generators63836
-Node: Creating Documents68349
-Node: Creating Mappings71819
-Node: Input/Options Specification75982
-Node: Creating Priors80405
-Node: The Preset Data Structure and Programatically Creating Sessions84242
-Node: Examples of Extending p-search87212
-Node: Candidate Generator Examples87695
-Node: A Candidate Generator with Hard-coded Items88149
-Node: Defining Custom Properties90050
+Node: Introduction3567
+Node: The Search Candidates5903
+Node: Candidate Mappings7364
+Node: Asserting Probabilities8599
+Node: Searching and Making Observations10394
+Node: Installation12004
+Node: Installing from Quelpa12468
+Node: Installing with Straight12878
+Node: Recommended Tooling13205
+Node: Getting Started13560
+Node: Creating the p-search session14000
+Node: Adding Search Criteria15790
+Node: Refining our Search19069
+Node: Final Results20848
+Node: The p-search Interface22330
+Node: Starting a session22649
+Node: The p-search session buffer25256
+Node: Candidate Generators26259
+Node: Creating and Editing Candidate Generators27536
+Node: Inputs and Options29821
+Node: Built-in Candidate Generator: FILESYSTEM30603
+Node: Built-in Candidate Generator: BUFFERS32498
+Node: Extension Candidate Generator: ELISP33072
+Node: Extension Candidate Generator: INFO33721
+Node: Extension Candidate Generator: PACKAGE-LIST34464
+Node: Mappings34935
+Node: Creating and Editing Mappings36375
+Node: Extension Mapping: File Split38154
+Node: Extension Mapping: Denote38606
+Node: Extension Mapping: PDF Info39639
+Node: Priors40364
+Node: Creating and Editing Priors41594
+Node: Scoring42771
+Node: Importance and Complement Options44108
+Node: Text Queries45979
+Node: Text Query Syntax48832
+Node: Fields52093
+Node: Searching Category53065
+Node: Instruction Strings53786
+Node: Git-related Priors54419
+Node: Filesystem-related Priors57031
+Node: Troubleshooting Priors58248
+Node: Search Results59144
+Node: Navigating and Viewing Search Results60146
+Node: Making Observations61680
+Node: Search Result Preview63162
+Node: Saving Sessions64573
+Node: Extending p-search64719
+Node: Creating Candidate Generators65349
+Node: Creating Documents69862
+Node: Creating Mappings73332
+Node: Input/Options Specification77495
+Node: Creating Priors81918
+Node: The Preset Data Structure and Programatically Creating Sessions85755
+Node: Examples of Extending p-search88725
+Node: Candidate Generator Examples89208
+Node: A Candidate Generator with Hard-coded Items89662
+Node: Defining Custom Properties91563
 
 End Tag Table
 

--- a/docs/p-search.texi
+++ b/docs/p-search.texi
@@ -571,7 +571,7 @@ options all begin with a dash.
 If you wanted to search all of your open buffers, you could create a
 ``BUFFERS'' candidate generator (the all caps naming for candidate
 generators is an arbitrary convention).  This has no associated
-configuration options.  Every buffer in your emacs session will then
+configuration options.  Every buffer in your Emacs session will then
 become a search candidate.
 
 

--- a/docs/p-search.texi
+++ b/docs/p-search.texi
@@ -578,20 +578,16 @@ become a search candidate.
 @node Extension Candidate Generator: ELISP
 @subsection Extension Candidate Generator: ELISP
 
-The function symbol candidate generator can be used to search function symbols along with their documentation.  When being created, you can provide it with the following options:
+The ELISP candidate generator (@code{psx-elisp}) can be used to search
+Emacs Lisp symbols along with their documentation.  When being created,
+you can provide it with the following option:
 
 @table @asis
-@item @kbd{s} Symbol Name Regex
-A regular expression which the symbol's name must match in order for it to be considered a candidate.  For example, if you wanted to search org functions, you could use the regular expression ``^org''.
-
-@item @kbd{-c} Is Command?
-When set to true, the candidate generator will only make documents for symbols that are defined as commands (i.e. with @code{(interactive)}).
-
-@item @kbd{-m} Major Mode
-Search for commands as if you were in the selected major mode and ran
-@kbd{M-X} (@code{execute-extended-command-for-buffer}) in a buffer of that mode.
+@item @kbd{t} Symbol Type @code{symbol-type}
+A keyword, one of: @code{:all} for all symbols (default),
+@code{:functions} for all function symbols, or @code{:variables} for all
+variables.
 @end table
-
 
 @node Extension Candidate Generator: INFO
 @subsection Extension Candidate Generator: INFO

--- a/docs/p-search.texi
+++ b/docs/p-search.texi
@@ -608,6 +608,11 @@ create a candidate generator for each.
 @node Extension Candidate Generator: PACKAGE-LIST
 @subsection Extension Candidate Generator: PACKAGE-LIST
 
+The PACKAGE-LIST candidate generator (@code{psx-package-list}) allows
+you to search through Emacs packages.  This candidate generator has no
+options, and will create documents for each package your installation
+knows about.
+
 @node Mappings
 @section Mappings
 

--- a/docs/p-search.texi
+++ b/docs/p-search.texi
@@ -525,8 +525,8 @@ provided however, you will always be prompted for its value for it not
 to be blank.
 
 
-@node Common Candidate Generators: FILESYSTEM
-@subsection Common Candidate Generators: FILESYSTEM
+@node Built-in Candidate Generator: FILESYSTEM
+@subsection Built-in Candidate Generator: FILESYSTEM
 
 The remainder of the candidate generator section will cover the
 candidate generators that come packaged in p-search.  The most
@@ -564,8 +564,8 @@ node_modules, which could make the search very slow.
 Note how required inputs in the transient menu are letters while the options all begin with a dash.
 
 
-@node Common Candidate Generators: BUFFERS
-@subsection Common Candidate Generators: BUFFERS
+@node Built-in Candidate Generator: BUFFERS
+@subsection Built-in Candidate Generator: BUFFERS
 
 If you wanted to search all of your open buffers, you could create a
 ``BUFFERS'' candidate generator (the all caps naming for candidate
@@ -574,8 +574,8 @@ configuration options.  Every buffer in your emacs session will then
 become a search candidate.
 
 
-@node Common Candidate Generators: FUNCTION-SYMBOL
-@subsection Common Candidate Generators: FUNCTION-SYMBOL
+@node Extension Candidate Generator: ELISP
+@subsection Extension Candidate Generator: ELISP
 
 The function symbol candidate generator can be used to search function symbols along with their documentation.  When being created, you can provide it with the following options:
 
@@ -592,8 +592,8 @@ Search for commands as if you were in the selected major mode and ran
 @end table
 
 
-@node Common Candidate Generators: INFO
-@subsection Common Candidate Generators: INFO
+@node Extension Candidate Generator: INFO
+@subsection Extension Candidate Generator: INFO
 
 p-search also provides a candidate generator to search info files. Once you select an info file, it will break it up into its constituent nodes which can be searched on.
 
@@ -605,6 +605,8 @@ The name of the info file to search.  The possible info files are taken from the
 
 If you wanted to search multiple info files at the same time, you can just create two candidate generators with the two info nodes.
 
+@node Extension Candidate Generator: PACKAGE-LIST
+@subsection Extension Candidate Generator: PACKAGE-LIST
 
 @node Mappings
 @section Mappings
@@ -649,6 +651,15 @@ After selecting the prior you want, you will the proceed to configure the mappin
 Mappings can be edited and killed simmilar to how candidate generators are, via @kbd{e} (@code{p-search-edit-dwim}) and @kbd{k} (@code{p-search-kill-entity-at-point}) respectively.
 
 A mapping works simmilar to the map function in the functional programming paradigm.  Each mapping has a function which takes in the candidate document (which is a set of key-value pairs), and returns one or more deriving documents, nil meaning nothing can be done, or @code{:remove}, which explicitly removes a document. Every mapping can be created with the option @kbd{-f} (@samp{filter}).  When on, a mapping that doesn't do anything to a document will remove the document.
+
+@node Extension Mapping: File Split
+@subsection Extension Mapping: File Split
+
+@node Extension Mapping: Denote
+@subsection Extension Mapping: Denote
+
+@node Extension Mapping: PDF Info
+@subsection Extension Mapping: PDF Info
 
 @node Priors
 @section Priors

--- a/docs/p-search.texi
+++ b/docs/p-search.texi
@@ -663,6 +663,37 @@ A mapping works simmilar to the map function in the functional programming parad
 @node Extension Mapping: Denote
 @subsection Extension Mapping: Denote
 
+The Denote mapping (@code{psx-denote}) provides a selection of
+denote-derived fields for search.  Mapped fields include as follows:
+
+@table @asis
+@item @code{denote-type}
+The type of the Denote document.
+
+@item @code{denote-identifier}
+The Denote document's identifier.
+
+@item @code{denote-signature}
+The Denote document's signature, if it exists and signatures are
+requested.
+
+@item @code{keywords}
+The Denote document's keywords, extracted from the filename.
+
+@item @code{title}
+The Denote document's title, extracted from the file name, and if
+different, from the file itself.
+@end table
+
+This mapping has one option, as follows:
+
+@table @asis
+@item @kbd{-s} Include Signature @code{include-signature}
+Whether document signatures should be included, when present.  The
+default for this value is provided by
+@code{psx-denote-include-signature-p}.
+@end table
+
 @node Extension Mapping: PDF Info
 @subsection Extension Mapping: PDF Info
 

--- a/docs/p-search.texi
+++ b/docs/p-search.texi
@@ -697,6 +697,35 @@ default for this value is provided by
 @node Extension Mapping: PDF Info
 @subsection Extension Mapping: PDF Info
 
+The PDF Info mapping (@code{psx-pdfinfo}) collects metadata from
+PDF documents.  There are no options on mapping creation, but the
+@code{psx-pdfinfo-executable} variable can be used to configure the
+location of your preferred @code{pdfinfo} command.  The following
+metadata fields are collected:
+
+@itemize
+@item @code{title}
+
+@item @code{keywords}
+
+@item @code{author}
+
+@item @code{creation-date}
+
+@item @code{modification-date}
+
+@item @code{pdf-subject}
+
+@item @code{pdf-creator}
+
+@item @code{pdf-producer}
+
+@item @code{pdf-pages}
+
+@item @code{pdf-pagesize}
+
+@end itemize
+
 @node Priors
 @section Priors
 

--- a/docs/p-search.texi
+++ b/docs/p-search.texi
@@ -537,22 +537,22 @@ prompted for the following arguments when creating a filesystem
 candidate generator:
 
 @table @asis
-@item @kbd{d} Directory
+@item @kbd{d} Directory (@code{base-directory})
 The directory from which all candidates will be produced.
 
-@item @kbd{f} Filename Pattern
+@item @kbd{f} Filename Pattern (@code{filename-regexp})
 A regular expression that all candidate files must match.  Use ``.*'' to match all files.
 
-@item @kbd{t} Search Tool
+@item @kbd{t} Search Tool (@code{search-tool})
 The CLI tool used to perform the term frequency search.  At the
 moment, the filesystem candidate generator supports the tools ripgrep
 (recommended), ag, and grep.  These tools will be used when creating a
 ``text query'' prior.
 
-@item @kbd{-i} Ignore Pattern
+@item @kbd{-i} Ignore Pattern (@code{ignore-pattern})
 A regular expression which can be provided to specify files not to match.
 
-@item @kbd{-g} Git ls-files
+@item @kbd{-g} Git ls-files (@code{use-git-ignore})
 Use the command @code{git ls-files} to enumerate the candidates.  If
 your directory is a Git repository, it is @strong{strongly}
 recommended that you turn this setting on to ignore files not
@@ -561,7 +561,8 @@ p-search attempting to search all vendored directories like
 node_modules, which could make the search very slow.
 @end table
 
-Note how required inputs in the transient menu are letters while the options all begin with a dash.
+Note how required inputs in the transient menu are letters while the
+options all begin with a dash.
 
 
 @node Built-in Candidate Generator: BUFFERS

--- a/docs/p-search.texi
+++ b/docs/p-search.texi
@@ -660,6 +660,14 @@ A mapping works simmilar to the map function in the functional programming parad
 @node Extension Mapping: File Split
 @subsection Extension Mapping: File Split
 
+The File Split mapping (@code{psx-file-split}) splits existing documents
+into smaller sections, based on a number of lines.  It has one option:
+
+@table @asis
+@item @kbd{n} Split by N lines @code{split-size}
+Number of lines to split documents by.
+@end table
+
 @node Extension Mapping: Denote
 @subsection Extension Mapping: Denote
 

--- a/docs/p-search.texi
+++ b/docs/p-search.texi
@@ -592,15 +592,18 @@ variables.
 @node Extension Candidate Generator: INFO
 @subsection Extension Candidate Generator: INFO
 
-p-search also provides a candidate generator to search info files. Once you select an info file, it will break it up into its constituent nodes which can be searched on.
+p-search also provides a candidate generator to search GNU Info
+documents (@code{psx-info}).  Once you select an Info file, it will be
+broken up into its constituent nodes for further search.
 
 @table @asis
-@item @kbd{i} Info Node
-The name of the info file to search.  The possible info files are taken from the variable @code{Info-directory-list}.
-
+@item @kbd{i} Info Node @code{info-node}
+The name of the info file to search.  The possible Info files are taken
+from the variable @code{Info-directory-list}.
 @end table
 
-If you wanted to search multiple info files at the same time, you can just create two candidate generators with the two info nodes.
+If you wanted to search multiple Info files at the same time, you can
+create a candidate generator for each.
 
 @node Extension Candidate Generator: PACKAGE-LIST
 @subsection Extension Candidate Generator: PACKAGE-LIST

--- a/extensions/psx-denote.el
+++ b/extensions/psx-denote.el
@@ -80,14 +80,7 @@
 (defun psx-denote--arg-display (_input-spec _output-spec arguments)
   "Display ARGUMENTS in a condensed format."
   (let-alist arguments
-    (format "category: %s, signature: %s"
-            (propertize
-             (cond
-              ((and .category-keywords .category-text) "both")
-              (.category-keywords "cat")
-              (.category-text "text")
-              (t "off"))
-             'face 'p-search-value)
+    (format "signature: %s"
             (propertize (if .include-signature "on" "off") 'face 'p-search-value))))
 
 (defconst psx-denote-mapping


### PR DESCRIPTION
This PR includes updates to the info manual to document the in-repository candidate generator and mapping extensions (`extensions/psx-*.el`).