### PR TITLE
psx-elisp.el: Fix syntax error

### DIFF
--- a/extensions/psx-elisp.el
+++ b/extensions/psx-elisp.el
@@ -80,7 +80,7 @@ Use either `describe-function' or `describe-variable'."
     (`(,symbol variable)
      (describe-variable symbol))
     (`(,symbol 'function)
-     (describe-function symbol)))
+     (describe-function symbol))))
 (p-search-def-function 'elisp 'p-search-goto-document #'psx-elisp--goto-doc)
 
 


### PR DESCRIPTION
This fixes a syntax error in psx-elisp.  Without this, it fails to load.