### PR TITLE
Fix category extraction, don't just look at the first category of a field

### DIFF
--- a/p-search.el
+++ b/p-search.el
@@ -1703,7 +1703,7 @@ Called with user supplied ARGS for the prior."
     (maphash
      (lambda (doc-id _)
        (let* ((fields (p-search-document-property doc-id 'fields)))
-         (pcase-dolist (`(,field-id ,vals) fields)
+         (pcase-dolist (`(,field-id . ,vals) fields)
            (when (and (eql (car (p-search-get-field field-id)) 'category)
                       (not (memq field-id fields)))
              (when (not (listp vals))


### PR DESCRIPTION
This PR fixes a bug in the category prior where only the first item in a list of categories would be extracted.

So for example, take the following document:

```
20240604T105100--straight__emacs_packages.md
Fields:
  keywords: ("emacs" "packages")
```

Before, when creating a category prior, only "emacs" would be seen and selectable in the completing read. Now it will show all available selections.